### PR TITLE
Removed the dependency of node-yamlparse module

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,7 +121,6 @@
     "vsce": "^2.14.0"
   },
   "dependencies": {
-    "@kubescape/yamlparse": "^0.1.0",
     "@kubescape/install": "^0.4.2",
     "abort-controller": "^3.0.0",
     "jsdom": "^19.0.0",

--- a/src/Kubescape/scan.ts
+++ b/src/Kubescape/scan.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 
-import { YamlHighlighter } from '@kubescape/yamlparse';
+import { YamlHighlighter } from './yamlParse';
 import { KubescapeApi } from '@kubescape/install';
 
 import { VscodeUi } from '../utils/ui';

--- a/src/Kubescape/yamlParse.ts
+++ b/src/Kubescape/yamlParse.ts
@@ -14,7 +14,7 @@ function checkAndUpdateIndent(startIndexAcc : StartIndexAccType, index : number)
   }
 }
 
-export class ResourceHighlightsHelperService {
+export class YamlHighlighter{
 
   static splitPathToSteps(path: string): string[] {
     const splitRegExp = new RegExp(/[a-zA-Z]+|\[[^[]+]/, 'g');
@@ -33,9 +33,9 @@ export class ResourceHighlightsHelperService {
   }
 
   static getStartAndEndIndexes(steps: string[], lines: string[]): IYamlHighlight {
-    const startIndexAcc = ResourceHighlightsHelperService.getStartIndexAcc(steps, lines);
+    const startIndexAcc = YamlHighlighter.getStartIndexAcc(steps, lines);
     const startIndex = startIndexAcc.startIndex;
-    const endIndex = ResourceHighlightsHelperService.getEndIndex(startIndex, lines, !!startIndexAcc.tempMatch);
+    const endIndex = YamlHighlighter.getEndIndex(startIndex, lines, !!startIndexAcc.tempMatch);
 
     return { startIndex, endIndex };
   }


### PR DESCRIPTION
The current VS Code extension is dependent on the node-yamlparse module for parsing yaml files, which isn’t required now as the current repo has all the required functions present in the yamlParse.ts file. So, I have made a small change to use the yamlparse.ts in src folder rather than being dependent on an external module.